### PR TITLE
Remove deprecation message on PHP 5.5

### DIFF
--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -58,11 +58,17 @@ class SecurityChecker
                 throw new \InvalidArgumentException(sprintf('Unsupported format "%s".', $format));
         }
 
+        $postFields = array('lock' => '@'.$lock);
+
+        if (version_compare(PHP_VERSION, '5.5.0') >= 0) {
+            $postFields['lock'] = new \CurlFile($lock);
+        }
+
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_HEADER, true);
         curl_setopt($curl, CURLOPT_URL, 'https://security.sensiolabs.org/check_lock');
         curl_setopt($curl, CURLOPT_HTTPHEADER, array('Accept: '.$accept));
-        curl_setopt($curl, CURLOPT_POSTFIELDS, array('lock' => '@'.$lock));
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $postFields);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($curl, CURLOPT_TIMEOUT, 10);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 1);


### PR DESCRIPTION
Using `@filename` in [CURLOPT_POSTFIELDS is deprecated in PHP 5.5](http://php.net/manual/en/function.curl-setopt.php). This PR uses the new `\CurlFile` class instead, removing two Deprecation messages that appear when running the `security:check` command.
