### PR TITLE
Require ext-curl in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "ext-curl": "*",
         "symfony/console": "~2.0"
     },
     "bin": ["security-checker"],


### PR DESCRIPTION
Since there is a hard coded dependency on curl, it should be required by composer.json.
