### PR TITLE
Change the way to check the PHP version

### DIFF
--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -62,7 +62,7 @@ class SecurityChecker
 
         $postFields = array('lock' => '@'.$lock);
 
-        if (version_compare(PHP_VERSION, '5.5.0') >= 0) {
+        if (PHP_VERSION_ID >= 50500) {
             $postFields['lock'] = new \CurlFile($lock);
         }
 


### PR DESCRIPTION
This is consistent with the change done in Symfony a while ago, allowing OPCache to optimize the condition at compile-time as it only involves static values rather than involving a function call