### PR TITLE
Properly inflect packages count when there is exactly 1 package

### DIFF
--- a/SensioLabs/Security/Formatters/SimpleFormatter.php
+++ b/SensioLabs/Security/Formatters/SimpleFormatter.php
@@ -40,7 +40,9 @@ class SimpleFormatter implements FormatterInterface
             $style = 'info';
         }
 
-        $output->writeln(sprintf('<%s>[%s] %d packages have known vulnerabilities</>', $style, $status, $count));
+        $output->writeln(
+            sprintf('<%s>[%s] %d %s known vulnerabilities</>', $style, $status, $count, $count == 1 ? 'package has' : 'packages have')
+        );
 
         if (0 !== $count) {
             $output->write("\n");

--- a/SensioLabs/Security/Formatters/TextFormatter.php
+++ b/SensioLabs/Security/Formatters/TextFormatter.php
@@ -42,7 +42,13 @@ class TextFormatter implements FormatterInterface
             $style = 'bg=green;fg=white';
         }
 
-        $output->writeln($this->formatter->formatBlock(array('['.$status.']', $count.' packages have known vulnerabilities'), $style, true));
+        $output->writeln(
+            $this->formatter->formatBlock(
+                array('['.$status.']', $count.' '.($count == 1 ? 'package has' : 'packages have').' known vulnerabilities'),
+                $style,
+                true
+            )
+        );
         $output->write("\n");
 
         if (0 !== $count) {


### PR DESCRIPTION
Just a minor grammar improvement.

Before:
```
[OK] 0 packages have known vulnerabilities
[CRITICAL] 1 packages have known vulnerabilities
[CRITICAL] 2 packages have known vulnerabilities
```
After:
```
[OK] 0 packages have known vulnerabilities
[CRITICAL] 1 package has known vulnerabilities
[CRITICAL] 2 packages have known vulnerabilities
```