### PR TITLE
Add support for lock as string

### DIFF
--- a/SensioLabs/Security/Crawler/CrawlerInterface.php
+++ b/SensioLabs/Security/Crawler/CrawlerInterface.php
@@ -19,7 +19,7 @@ interface CrawlerInterface
     /**
      * Checks a Composer lock file.
      *
-     * @param string $lock The path to the composer.lock file
+     * @param string $lock The path to the composer.lock file or a string able to be opened via file_get_contents
      *
      * @return An array of two items: the number of vulnerabilities and an array of vulnerabilities
      */

--- a/SensioLabs/Security/Crawler/CurlCrawler.php
+++ b/SensioLabs/Security/Crawler/CurlCrawler.php
@@ -36,18 +36,14 @@ class CurlCrawler extends BaseCrawler
         if (false === $curl = curl_init()) {
             throw new RuntimeException('Unable to create a cURL handle.');
         }
-        $tmplock = tempnam(sys_get_temp_dir(), 'sensiolabs_security');
-        $handle = fopen($tmplock, 'w');
-        fwrite($handle, $this->getLockContents($lock));
-        fclose($handle);
 
-        $postFields = array('lock' => PHP_VERSION_ID >= 50500 ? new \CurlFile($tmplock) : '@'.$tmplock);
+        $lock = new \CurlFile('data://text/plain;base64,'.base64_encode($this->getLockContents($lock)), 'text/plain', 'composer.lock');
 
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_HEADER, true);
         curl_setopt($curl, CURLOPT_URL, $this->endPoint);
         curl_setopt($curl, CURLOPT_HTTPHEADER, array('Accept: application/json'));
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $postFields);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, array('lock' => $lock));
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->timeout);
         curl_setopt($curl, CURLOPT_TIMEOUT, 10);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, ini_get('open_basedir') ? 0 : 1);
@@ -59,8 +55,6 @@ class CurlCrawler extends BaseCrawler
         curl_setopt($curl, CURLOPT_USERAGENT, sprintf('SecurityChecker-CLI/%s CURL PHP', SecurityChecker::VERSION));
 
         $response = curl_exec($curl);
-
-        unlink($tmplock);
 
         if (false === $response) {
             $error = curl_error($curl);

--- a/SensioLabs/Security/Crawler/DefaultCrawler.php
+++ b/SensioLabs/Security/Crawler/DefaultCrawler.php
@@ -17,10 +17,12 @@ namespace SensioLabs\Security\Crawler;
 class DefaultCrawler implements CrawlerInterface
 {
     private $crawler;
+    private $fgc;
 
     public function __construct()
     {
-        $this->crawler = function_exists('curl_init') ? new CurlCrawler() : new FileGetContentsCrawler();
+        $this->fgc = new FileGetContentsCrawler();
+        $this->crawler = function_exists('curl_init') ? new CurlCrawler() : $this->fgc;
     }
 
     /**
@@ -28,7 +30,12 @@ class DefaultCrawler implements CrawlerInterface
      */
     public function check($lock)
     {
-        return $this->crawler->check($lock);
+        if (0 !== strpos($lock, 'data://text/plain;base64,')) {
+            return $this->crawler->check($lock);
+        }
+
+        // we must use FileGetContentsCrawler() here
+        return $this->fgc->check($lock);
     }
 
     /**

--- a/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
+++ b/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
@@ -31,7 +31,7 @@ class FileGetContentsCrawler extends BaseCrawler
             'http' => array(
                 'method' => 'POST',
                 'header' => "Content-Type: multipart/form-data; boundary=$boundary\r\nAccept: application/json",
-                'content' => "--$boundary\r\nContent-Disposition: form-data; name=\"lock\"; filename=\"$lock\"\r\nContent-Type: application/octet-stream\r\n\r\n".$this->getLockContents($lock)."\r\n--$boundary--\r\n",
+                'content' => "--$boundary\r\nContent-Disposition: form-data; name=\"lock\"; filename=\"composer.lock\"\r\nContent-Type: application/octet-stream\r\n\r\n".$this->getLockContents($lock)."\r\n--$boundary--\r\n",
                 'ignore_errors' => true,
                 'follow_location' => true,
                 'max_redirects' => 3,

--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -39,14 +39,16 @@ class SecurityChecker
      */
     public function check($lock)
     {
-        if (is_dir($lock) && file_exists($lock.'/composer.lock')) {
-            $lock = $lock.'/composer.lock';
-        } elseif (preg_match('/composer\.json$/', $lock)) {
-            $lock = str_replace('composer.json', 'composer.lock', $lock);
-        }
+        if (0 !== strpos($lock, 'data://text/plain;base64,')) {
+            if (is_dir($lock) && file_exists($lock.'/composer.lock')) {
+                $lock = $lock.'/composer.lock';
+            } elseif (preg_match('/composer\.json$/', $lock)) {
+                $lock = str_replace('composer.json', 'composer.lock', $lock);
+            }
 
-        if (!is_file($lock)) {
-            throw new RuntimeException('Lock file does not exist.');
+            if (!is_file($lock)) {
+                throw new RuntimeException('Lock file does not exist.');
+            }
         }
 
         list($this->vulnerabilityCount, $vulnerabilities) = $this->crawler->check($lock);


### PR DESCRIPTION
Allows to do something like this:

```php
<?php

require_once __DIR__.'/vendor/autoload.php';

$checker = new SensioLabs\Security\SecurityChecker();
$lock = 'data://text/plain;base64,'.base64_encode(file_get_contents($lock_as_string));
print_r($checker->check($lock));
```
