### PR TITLE
Fix setting certificate locations

### DIFF
--- a/SensioLabs/Security/Crawler/CurlCrawler.php
+++ b/SensioLabs/Security/Crawler/CurlCrawler.php
@@ -58,8 +58,14 @@ class CurlCrawler extends BaseCrawler
         curl_setopt($curl, CURLOPT_FAILONERROR, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($curl, CURLOPT_CAINFO, CaBundle::getSystemCaRootBundlePath());
         curl_setopt($curl, CURLOPT_USERAGENT, sprintf('SecurityChecker-CLI/%s CURL PHP', SecurityChecker::VERSION));
+
+        $caPathOrFile = CaBundle::getSystemCaRootBundlePath();
+        if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+            curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
+        } else {
+            curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);
+        }
 
         $response = curl_exec($curl);
 

--- a/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
+++ b/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
@@ -34,7 +34,8 @@ class FileGetContentsCrawler extends BaseCrawler
         foreach ($contextualHeaders as $key => $value) {
             $headers .= "\r\n$key: $value";
         }
-        $context = stream_context_create(array(
+
+        $opts = array(
             'http' => array(
                 'method' => 'POST',
                 'header' => $headers,
@@ -46,12 +47,19 @@ class FileGetContentsCrawler extends BaseCrawler
                 'user_agent' => sprintf('SecurityChecker-CLI/%s FGC PHP', SecurityChecker::VERSION),
             ),
             'ssl' => array(
-                'cafile' => CaBundle::getSystemCaRootBundlePath(),
                 'verify_peer' => 1,
                 'verify_host' => 2,
             ),
-        ));
+        );
 
+        $caPathOrFile = CaBundle::getSystemCaRootBundlePath();
+        if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+            $opts['ssl']['capath'] = $caPathOrFile;
+        } else {
+            $opts['ssl']['cafile'] = $caPathOrFile;
+        }
+
+        $context = stream_context_create($opts);
         $level = error_reporting(0);
         $body = file_get_contents($this->endPoint, 0, $context);
         error_reporting($level);


### PR DESCRIPTION
`CaBundle::getSystemCaRootBundlePath()` can return either the CA path or file.

`CURLOPT_CAINFO` expects a file so when passing a path security-checker command fails.

This is my system cert locations:

```
$ php -r 'print_r(openssl_get_cert_locations());'
Array
(
    [default_cert_file] => /usr/lib/ssl/cert.pem
    [default_cert_file_env] => SSL_CERT_FILE
    [default_cert_dir] => /usr/lib/ssl/certs
    [default_cert_dir_env] => SSL_CERT_DIR
    [default_private_dir] => /usr/lib/ssl/private
    [default_default_cert_area] => /usr/lib/ssl
    [ini_cafile] =>
    [ini_capath] => /usr/lib/ssl/certs
)
```

If I run `vendor/bin/security-checker -vvv security:check composer.lock`

When using `CurlCrawler` I get the following error:
> An error occurred: error setting certificate verify locations:
>  CAfile: /usr/lib/ssl/certs
>  CApath: /etc/ssl/certs.

When using `FileGetContentsCrawler` I get the following error:
> An error occurred: file_get_contents(https://security.sensiolabs.org/check_lock): failed to open stream: operation failed.

Usage section of composer/ca-bundle recommends checking with is_dir:
> https://github.com/composer/ca-bundle