### PR TITLE
Enable lazy loading of security:check command

### DIFF
--- a/SensioLabs/Security/Command/SecurityCheckerCommand.php
+++ b/SensioLabs/Security/Command/SecurityCheckerCommand.php
@@ -24,6 +24,8 @@ use SensioLabs\Security\Formatters\TextFormatter;
 
 class SecurityCheckerCommand extends Command
 {
+    protected static $defaultName = 'security:check';
+
     private $checker;
 
     public function __construct(SecurityChecker $checker)


### PR DESCRIPTION
Similar to https://github.com/symfony/recipes/pull/339 but this also lazy loads the command with console >=3.4  if someone does not use flex.