### PR TITLE
Added Usage for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Use the code from the repository directly:
 
     $ composer install
     $ php security-checker security:check /path/to/composer.lock
+    
+Use docker image:
+
+    $ docker run -v `pwd`:/app tico/security-check security:check composer.lock
 
 Integration
 -----------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the code from the repository directly:
     
 Use docker image:
 
-    $ docker run -v `pwd`:/app tico/security-check security:check composer.lock
+    $ docker run -v `pwd`:/app tico/security-checker security:check composer.lock
 
 Integration
 -----------


### PR DESCRIPTION
Hello!
We created docker image for security checker. It's must-have for dockerized projects, to run such tools as docker images on CI/CD server

PS: If you want, I can add security checker maintainers to docker hub repo team, so you will have control on it