### PR TITLE
use timeout for CURLOPT_TIMEOUT as well

### DIFF
--- a/SensioLabs/Security/Crawler/CurlCrawler.php
+++ b/SensioLabs/Security/Crawler/CurlCrawler.php
@@ -49,7 +49,7 @@ class CurlCrawler extends BaseCrawler
         curl_setopt($curl, CURLOPT_HTTPHEADER, array('Accept: application/json'));
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postFields);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->timeout);
-        curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+        curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, ini_get('open_basedir') ? 0 : 1);
         curl_setopt($curl, CURLOPT_MAXREDIRS, 3);
         curl_setopt($curl, CURLOPT_FAILONERROR, false);


### PR DESCRIPTION
Due to the timeout being set only for `CONNECTTIMEOUT` and `TIMEOUT` being hard coded 10 it was causing the following error.

```
An error occurred: Resolving timed out after 10520 milliseconds.
```

Not sure if we should have another timeout setting, but using for both seems to do the trick - even with the default 20 seconds.