### PR TITLE
Add the ability to exclude CVEs

### DIFF
--- a/SensioLabs/Security/Command/SecurityCheckerCommand.php
+++ b/SensioLabs/Security/Command/SecurityCheckerCommand.php
@@ -47,6 +47,12 @@ class SecurityCheckerCommand extends Command
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format', 'text'),
                 new InputOption('end-point', '', InputOption::VALUE_REQUIRED, 'The security checker server URL'),
                 new InputOption('timeout', '', InputOption::VALUE_REQUIRED, 'The HTTP timeout in seconds'),
+                new InputOption(
+                    'excluded-cves',
+                    '',
+                    InputOption::VALUE_REQUIRED,
+                    'A list of CVEs which will not be reported (separate CVEs with a comma)'
+                )
             ))
             ->setDescription('Checks security issues in your project dependencies')
             ->setHelp(<<<EOF
@@ -79,6 +85,11 @@ EOF
 
         if ($timeout = $input->getOption('timeout')) {
             $this->checker->getCrawler()->setTimeout($timeout);
+        }
+
+        if ($excludedCVEs = $input->getOption('excluded-cves')) {
+            $excludedCVEs = explode(',', $excludedCVEs);
+            $this->checker->getCrawler()->setExcludedCVEs($excludedCVEs);
         }
 
         try {

--- a/SensioLabs/Security/Crawler/CrawlerInterface.php
+++ b/SensioLabs/Security/Crawler/CrawlerInterface.php
@@ -28,4 +28,11 @@ interface CrawlerInterface
     public function setTimeout($timeout);
 
     public function setEndPoint($endPoint);
+
+    /**
+     * Specifies a list of CVEs which will not be reported.
+     *
+     * @param string[] $cves
+     */
+    public function setExcludedCVEs(array $cves);
 }

--- a/SensioLabs/Security/Crawler/DefaultCrawler.php
+++ b/SensioLabs/Security/Crawler/DefaultCrawler.php
@@ -46,4 +46,12 @@ class DefaultCrawler implements CrawlerInterface
     {
         $this->crawler->setEndPoint($endPoint);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExcludedCVEs(array $cves)
+    {
+        $this->crawler->setExcludedCVEs($cves);
+    }
 }


### PR DESCRIPTION
As mentioned in #119, this allows passing an array of CVEs to the crawler which will then be excluded from the report.

Command line usage would look like this:

```
$ php security-checker security:check composer.lock --excluded-cves=CVE-2018-14773,CVE-2018-11407
``` 

I am, however, not sure if it should be implemented in this way. Maybe the API should provide an option to pass a list of CVEs to ignore?