### PR TITLE
Use interface instead of direct implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ the checker into your own project:
         $checker = new SecurityChecker();
         $result = $checker->check('/path/to/composer.lock', 'json');
         $alerts = json_decode((string) $result, true);
+        
+ * using this last method, you can also pass on any Result parser that implements the Result interface:
+
+        use SensioLabs\Security\SecurityChecker;
+        use SensioLabs\Security\Result;
+
+        // Class passed on as the second argument here will be the one that collects all results
+        $checker = new SecurityChecker(null, new Result());
+        $result = $checker->check('/path/to/composer.lock', 'json');
+        $alerts = json_decode((string) $result, true);
+         
 
 [1]: https://security.symfony.com/
 [2]: https://github.com/FriendsOfPHP/security-advisories

--- a/SensioLabs/Security/Command/SecurityCheckerCommand.php
+++ b/SensioLabs/Security/Command/SecurityCheckerCommand.php
@@ -57,8 +57,8 @@ You can also pass the path to a <info>composer.lock</info> file as an argument:
 
 <info>php %command.full_name% /path/to/composer.lock</info>
 
-By default, the command displays the result in plain text, but you can also
-configure it to output JSON instead by using the <info>--format</info> option:
+By default, the command displays the result in ansi formatted text, but you can
+also configure it to output JSON instead by using the <info>--format</info> option:
 
 <info>php %command.full_name% /path/to/composer.lock --format=json</info>
 EOF
@@ -68,6 +68,9 @@ EOF
     /**
      * @see Command
      * @see SecurityChecker
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/SensioLabs/Security/Crawler.php
+++ b/SensioLabs/Security/Crawler.php
@@ -66,6 +66,11 @@ class Crawler
      */
     public function check($lock, $format = 'json', array $headers = [])
     {
+        // Be able to force another pre-set format, determined by the object itself
+        if ($this->result->getFormat() !== null) {
+            $format = $this->result->getFormat();
+        }
+
         list($headers, $body) = $this->doCheck($lock, $format, $headers);
 
         if (!(preg_match('/X-Alerts: (\d+)/', $headers, $matches) || 2 === count($matches))) {

--- a/SensioLabs/Security/Interfaces/Result.php
+++ b/SensioLabs/Security/Interfaces/Result.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SensioLabs\Security\Interfaces;
+
+/**
+ * Any class that implements this interface will be able to be used in the SecurityChecker
+ *
+ * Interface Result
+ * @package SensioLabs\Security\Interfaces
+ */
+interface Result {
+    /**
+     * Fills in the data
+     *
+     * @param $count
+     * @param $vulnerabilities
+     * @param $format
+     * @return mixed
+     */
+    public function fill($count, $vulnerabilities, $format);
+
+    /**
+     * Which format was passed on
+     *
+     * @return mixed
+     */
+    public function getFormat();
+
+    /**
+     * How many security vulnerabilities were found
+     *
+     * @return mixed
+     */
+    public function count();
+}

--- a/SensioLabs/Security/Interfaces/Result.php
+++ b/SensioLabs/Security/Interfaces/Result.php
@@ -8,28 +8,46 @@ namespace SensioLabs\Security\Interfaces;
  * Interface Result
  * @package SensioLabs\Security\Interfaces
  */
-interface Result {
+interface Result extends \Countable {
     /**
      * Fills in the data
      *
-     * @param $count
-     * @param $vulnerabilities
-     * @param $format
-     * @return mixed
+     * @param int $count
+     * @param string $vulnerabilities
+     * @param string $format
+     * @return self
      */
     public function fill($count, $vulnerabilities, $format);
 
     /**
-     * Which format was passed on
+     * Which format was passed on or does this class use
      *
-     * @return mixed
+     * If set manually, choose one of:
+     *   text
+     *   simple
+     *   markdown
+     *   yaml
+     *   json
+     *   ansi
+     *
+     * @see \SensioLabs\Security\Crawler::getContentType
+     *
+     *
+     * @return string
      */
     public function getFormat();
 
     /**
      * How many security vulnerabilities were found
      *
-     * @return mixed
+     * @return int
      */
     public function count();
+
+    /**
+     * What to print when casting this object to a string
+     *
+     * @return string
+     */
+    public function __toString();
 }

--- a/SensioLabs/Security/Result.php
+++ b/SensioLabs/Security/Result.php
@@ -11,17 +11,20 @@
 
 namespace SensioLabs\Security;
 
-class Result implements \Countable
+use SensioLabs\Security\Interfaces\Result as ResultInterface;
+
+class Result implements \Countable, ResultInterface
 {
     private $count;
     private $vulnerabilities;
     private $format;
 
-    public function __construct($count, $vulnerabilities, $format)
+    public function fill($count, $vulnerabilities, $format)
     {
         $this->count = $count;
         $this->vulnerabilities = $vulnerabilities;
         $this->format = $format;
+        return $this;
     }
 
     public function getFormat()

--- a/SensioLabs/Security/Result.php
+++ b/SensioLabs/Security/Result.php
@@ -13,7 +13,13 @@ namespace SensioLabs\Security;
 
 use SensioLabs\Security\Interfaces\Result as ResultInterface;
 
-class Result implements \Countable, ResultInterface
+/**
+ * Catch-all class that is able to deal with all type of formats in one go
+ *
+ * Class Result
+ * @package SensioLabs\Security
+ */
+class Result implements ResultInterface
 {
     private $count;
     private $vulnerabilities;

--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -18,6 +18,9 @@ class SecurityChecker
 {
     const VERSION = '5.0';
 
+    /**
+     * @var Crawler
+     */
     private $crawler;
 
     public function __construct(Crawler $crawler = null, ResultInterface $result = null)

--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -12,6 +12,7 @@
 namespace SensioLabs\Security;
 
 use SensioLabs\Security\Exception\RuntimeException;
+use SensioLabs\Security\Interfaces\Result as ResultInterface;
 
 class SecurityChecker
 {
@@ -19,9 +20,9 @@ class SecurityChecker
 
     private $crawler;
 
-    public function __construct(Crawler $crawler = null)
+    public function __construct(Crawler $crawler = null, ResultInterface $result = null)
     {
-        $this->crawler = null === $crawler ? new Crawler() : $crawler;
+        $this->crawler = null === $crawler ? new Crawler($result) : $crawler;
     }
 
     /**
@@ -31,7 +32,7 @@ class SecurityChecker
      * @param string $format  The format of the result
      * @param array  $headers An array of headers to add for this specific HTTP request
      *
-     * @return Result
+     * @return ResultInterface
      *
      * @throws RuntimeException When the lock file does not exist
      * @throws RuntimeException When the certificate can not be copied
@@ -40,7 +41,7 @@ class SecurityChecker
     {
         if (0 !== strpos($lock, 'data://text/plain;base64,')) {
             if (is_dir($lock) && file_exists($lock.'/composer.lock')) {
-                $lock = $lock.'/composer.lock';
+                $lock .= '/composer.lock';
             } elseif (preg_match('/composer\.json$/', $lock)) {
                 $lock = str_replace('composer.json', 'composer.lock', $lock);
             }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-json": "*",
         "symfony/console": "~2.7|~3.0|~4.0",
         "composer/ca-bundle": "^1.0"
     },


### PR DESCRIPTION
Hi!

I needed to perform machine-parseable actions on the result set of a security analysis in order to integrate this library with our CI/CD servers, and the fastest way was to implement my own class around it.

So in order to do that, I thought it was a good idea to interface the sh*t out of things, so this PR was born.

I think this will help with #114, #119 and definitively #121 (as our use case is pretty similar to that last one).

I will be creating some implementation examples in an apart repository soon to enlighten the usage. I did not add a new command line option, but you'll have to provide a `Result` implementation to the `Crawler()` object:

before:
```
$console = new Application('SensioLabs Security Checker', SecurityChecker::VERSION);
$console->add(
    new SecurityCheckerCommand(
        new SecurityChecker(
            new Crawler()
        )
    )
);
$console->run();
```

now:
```
$console = new Application('SensioLabs Security Checker', SecurityChecker::VERSION);
// Optional: if no object is passed on, Result will be used
$console->add(
    new SecurityCheckerCommand(
        new SecurityChecker(
            new Crawler(
                // Optional object
                new JUnitFormattedOutput()
            )
        )
    )
);
$console->run();
```

AFAIK, no BC issues were introduced, only new functionality was added.

Greetings and thanks for this package!