### PR TITLE
Ignore case on HTTP header (HTTP/2 compatibility) - 4.1 branch

### DIFF
--- a/SensioLabs/Security/Crawler/BaseCrawler.php
+++ b/SensioLabs/Security/Crawler/BaseCrawler.php
@@ -54,7 +54,7 @@ abstract class BaseCrawler implements CrawlerInterface
             throw $e;
         }
 
-        if (!(preg_match('/X-Alerts: (\d+)/', $headers, $matches) || 2 == count($matches))) {
+        if (!(preg_match('/X-Alerts: (\d+)/i', $headers, $matches) || 2 == count($matches))) {
             throw new RuntimeException('The web service did not return alerts count.');
         }
 

--- a/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
+++ b/SensioLabs/Security/Crawler/FileGetContentsCrawler.php
@@ -79,7 +79,7 @@ class FileGetContentsCrawler extends BaseCrawler
 
         $headers = '';
         foreach ($http_response_header as $header) {
-            if (false !== strpos($header, 'X-Alerts: ')) {
+            if (false !== stripos($header, 'X-Alerts: ')) {
                 $headers = $header;
             }
         }


### PR DESCRIPTION
see #145

As stated in the RFC of HTTP/2 header field names MUST be converted to lowercase.