### PR TITLE
Add Note Regarding Old Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ calls to the security.symfony.com API):
 
     $ symfony security:check
 
-*Note: Previous versions of security-checker used: `security.sensiolabs.org`. That domain is no longer available for use and has been replaced by `security.symphony.com`. Please upgrade to version 5 of this library to fix errors with the old domain.
+*Note: Previous versions of security-checker used: `security.sensiolabs.org`. That domain is no longer available for use and has been replaced by `security.symfony.com`. Please upgrade to version 5 of this library to fix errors with the old domain.
 See: https://github.com/sensiolabs/security-checker/issues/149*
 
 Usage

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ calls to the security.symfony.com API):
 
     $ symfony security:check
 
+*Note: Previous versions of security-checker used: `security.sensiolabs.org`. That domain is no longer available for use and has been replaced by `security.symphony.com`. Please upgrade to version 5 of this library to fix errors with the old domain.
+See: https://github.com/sensiolabs/security-checker/issues/149*
+
 Usage
 -----
 


### PR DESCRIPTION
**Problem**
The old domain, `security.sensiolabs.org` has ceased operations and will no longer work. The new domain is `security.symfony.com`. Users will need to update to version 5+ of `security-checker` to use the new domain.

**Steps Taken**
Add a note to the readme giving temporarily giving some more information.