### PR TITLE
Make security-checker compatible with Sf 5

### DIFF
--- a/SensioLabs/Security/Command/SecurityCheckerCommand.php
+++ b/SensioLabs/Security/Command/SecurityCheckerCommand.php
@@ -101,5 +101,7 @@ EOF
         if (\count($result) > 0) {
             return 1;
         }
+
+        return 0;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/console": "^2.8|^3.4|^4.2",
-        "symfony/http-client": "^4.3",
-        "symfony/mime": "^4.3",
+        "symfony/console": "^2.8|^3.4|^4.2|^5.0",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/mime": "^4.3|^5.0",
         "symfony/polyfill-ctype": "^1.11"
     },
     "bin": ["security-checker"],


### PR DESCRIPTION
Add return 0 when everything is fine on the security-checker command
Add ^5.0 in composer.json for symfony dependencies
#hackdayparis