### PR TITLE
feat: Adding date and time of command run

### DIFF
--- a/SensioLabs/Security/Command/SecurityCheckerCommand.php
+++ b/SensioLabs/Security/Command/SecurityCheckerCommand.php
@@ -92,6 +92,8 @@ EOF
         }
 
         $output->writeln((string) $result);
+        $dateTimeObject = new \DateTime();
+        $output->writeln('Security Checker command run at ' . $dateTimeObject->format('l F Y H:i:s e') . PHP_EOL);
 
         if (count($result) > 0) {
             return 1;


### PR DESCRIPTION
Adding in a line to reference the time that the Security Checker command was run as it can be useful for auditing when included in build plans. 